### PR TITLE
自動デプロイするために GitHub Actions の設定を追加

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,2 @@
+*id_rsa
+*id_rsa.pub

--- a/.github/scripts/deploy.bash
+++ b/.github/scripts/deploy.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eux
+
+# setup ssh-agent and provide the GitHub deploy key
+eval "$(ssh-agent -s)"
+mkdir -p /root/.ssh
+ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts
+echo "${DEPLOY_KEY}" > /root/.ssh/id_rsa
+chmod 400 /root/.ssh/id_rsa
+
+# commit the assets in docs/ if changed, and push to GitHub using SSH
+git config user.name "${GIT_NAME}"
+git config user.email "${GIT_EMAIL}"
+git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
+
+git checkout ${TARGET_BRANCH}
+git status
+git add ${TARGET_PATH}
+git diff --staged --quiet || git commit -m "Update docs by GitHub Actions"
+git push origin ${TARGET_BRANCH}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'
-    - run: npm install
+    - run: npm ci
     - run: npm run-script build
     - name: deploy
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
     - name: cache for elm
       uses: actions/cache@v1
       with:
-        path: elm-stuff
+        path: ~/.elm
         key: ${{ runner.os }}-elm-${{ hashFiles('**/elm.json') }}
         restore-keys: |
           ${{ runner.os }}-elm-

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,48 @@
+name: GitHub Pages
+
+on:
+  pull_request: null
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - "dist/**"
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: cache for node
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: cache for elm
+      uses: actions/cache@v1
+      with:
+        path: elm-stuff
+        key: ${{ runner.os }}-elm-${{ hashFiles('**/elm.json') }}
+        restore-keys: |
+          ${{ runner.os }}-elm-
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: npm install
+    - run: npm run-script build
+    - name: deploy
+      if: github.ref == 'refs/heads/master'
+      uses: docker://buildpack-deps:18.04-scm
+      env:
+        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        GIT_NAME: Bot
+        GIT_EMAIL: example@example.com
+        TARGET_BRANCH: master
+        TARGET_PATH: dist
+      with:
+        entrypoint: /bin/bash
+        args: .github/scripts/deploy.bash


### PR DESCRIPTION
Close: #6 

PR の場合はビルドまで、master push の場合はデプロイまでやります。
一応、node と elm-stuff をキャッシュしてます([node_module のキャッシュは非推奨なんだって](https://github.com/actions/cache/blob/master/examples.md#node---npm))

あとは設定で、リポジトリへの公開鍵を設定して、その秘密鍵を Secret に DEPLOY_KEY で設定すれば動作するはず。

### ToDo

- [x] 鍵の設定
